### PR TITLE
fix: clarify rate limit export failure

### DIFF
--- a/Tampermonkey.js
+++ b/Tampermonkey.js
@@ -1057,7 +1057,12 @@
         const resolvedWorkspaceId = resolveWorkspaceId(workspaceId);
         if (resolvedWorkspaceId) { headers['ChatGPT-Account-Id'] = resolvedWorkspaceId; }
         const r = await fetch(`/backend-api/conversation/${id}`, { headers });
-        if (!r.ok) throw new Error(`获取对话详情失败 conv ${id} (${r.status})`);
+        if (!r.ok) {
+            if (r.status === 429) {
+                throw new Error(`获取对话详情失败 conv ${id}：官方接口限流 (429)。请降低导出频率、减少单次导出的对话数量，等待几分钟后再试。`);
+            }
+            throw new Error(`获取对话详情失败 conv ${id} (${r.status})`);
+        }
         const j = await r.json();
         j.__fetched_at = new Date().toISOString();
         return j;

--- a/chrome-extension/exporter.user.js
+++ b/chrome-extension/exporter.user.js
@@ -1039,7 +1039,12 @@
         const resolvedWorkspaceId = resolveWorkspaceId(workspaceId);
         if (resolvedWorkspaceId) { headers['ChatGPT-Account-Id'] = resolvedWorkspaceId; }
         const r = await fetch(`/backend-api/conversation/${id}`, { headers });
-        if (!r.ok) throw new Error(`获取对话详情失败 conv ${id} (${r.status})`);
+        if (!r.ok) {
+            if (r.status === 429) {
+                throw new Error(`获取对话详情失败 conv ${id}：官方接口限流 (429)。请降低导出频率、减少单次导出的对话数量，等待几分钟后再试。`);
+            }
+            throw new Error(`获取对话详情失败 conv ${id} (${r.status})`);
+        }
         const j = await r.json();
         j.__fetched_at = new Date().toISOString();
         return j;


### PR DESCRIPTION
## 概要

导出大量对话时，ChatGPT 后端可能返回 `429 Too Many Requests`。目前用户只能从控制台看出是限流，提示不够直接。

本 PR 针对获取对话详情时的 `429` 增加明确提示，告知用户这是官方接口限流，并建议降低导出频率、减少单次导出数量、等待几分钟后再试，避免用户反复重试导致更频繁触发限流或账号风控。

## 修改内容

- 在 `getConversation()` 中针对 `429` 增加专门错误提示。
- 非 `429` 错误保持原有提示和行为不变。
- 同步更新 Tampermonkey 脚本和 Chrome 扩展脚本。

## 验证

- `node --check Tampermonkey.js`
- `node --check chrome-extension/exporter.user.js`
- `git diff --check`